### PR TITLE
- Fixed missing prereqs Module::Runtime.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ perl                     = 5.10.0
 Moo                      = 0
 List::MoreUtils          = 0
 Carp                     = 0
+Module::Runtime          = 0
 
 [Prereqs / TestRequires]
 Test::More      = 0


### PR DESCRIPTION
Hi Tiago, please review the above change as reported by CPANTS.

http://cpants.cpanauthors.org/dist/MooX-Role-Parameterized/errors

Many Thanks.
Best Regards,
Mohammad S Anwar