### PR TITLE
Fallback on Role::Tiny role when applying

### DIFF
--- a/lib/MooX/Role/Parameterized/With.pm
+++ b/lib/MooX/Role/Parameterized/With.pm
@@ -7,6 +7,7 @@ use warnings;
 use Exporter;    # qw(import);
 use Module::Runtime qw(use_module);
 use List::MoreUtils qw(natatime);
+use Role::Tiny;
 
 sub import {
     my $package = shift;
@@ -15,7 +16,16 @@ sub import {
     my $it = natatime( 2, @_ );
 
     while ( my ( $role, $params ) = $it->() ) {
-        use_module($role)->apply( $params, target => $target );
+        my $mod = use_module($role);
+        if (%$params) {
+            $mod->apply( $params, target => $target );
+        } else {
+            if ($mod->can("apply")) {
+                $mod->apply( $params, target => $target );
+            } else {
+                Role::Tiny->apply_roles_to_package( $target, $mod );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This simplistic commit checks if the parameters are empty ({}) and if they are,
when a role package does not have apply(), fallback to applying using
Role::Tiny->apply_roles_to_package().

This commit is basically just a proof of concept to make classes that use
MooX::Role::Parameterized::With work with Role::Tiny and Moo::Role roles.

One caveat is that the required methods must be declared before including the
role, e.g.:

    package Role1;
    use Role::Tiny;
    requires 'meth1';

    package Class1;
    sub meth1 { ... }
    use MooX::Role::Parameterized::With 'Role1' => {};

A solution for that is for MooX::Role::Parameterized::With to declare 'with'. A
syntax that is compatible with Moose to support non-parametric and parametric
including would be nice, e.g.:

    with 'Role1', 'Role2' => {param=>'for',role=>'Role2'}, ...;