### PR TITLE
Fallback on Moo::Role/Role::Tiny role when applying

### DIFF
--- a/lib/MooX/Role/Parameterized/With.pm
+++ b/lib/MooX/Role/Parameterized/With.pm
@@ -7,6 +7,8 @@ use warnings;
 use Exporter;    # qw(import);
 use Module::Runtime qw(use_module);
 use List::MoreUtils qw(natatime);
+use Moo::Role qw();
+use Role::Tiny qw();
 
 sub import {
     my $package = shift;
@@ -15,7 +17,22 @@ sub import {
     my $it = natatime( 2, @_ );
 
     while ( my ( $role, $params ) = $it->() ) {
-        use_module($role)->apply( $params, target => $target );
+        use_module($role);
+        if (%$params) {
+            $role->apply( $params, target => $target );
+        } else {
+            if ($role->can("apply")) {
+                $role->apply( $params, target => $target );
+            } elsif (Moo::Role->is_role($role)) {
+                Moo::Role->apply_roles_to_package( $target, $role );
+                Moo::Role->_maybe_reset_handlemoose($target);
+            } elsif (Role::Tiny->is_role($role)) {
+                Role::Tiny->apply_roles_to_package( $target, $role );
+            } else {
+                die "Can't apply $role to $target: $role is neither a ".
+                    "MooX::Role::Parameterized/Moo::Role/Role::Tiny role";
+            }
+        }
     }
 }
 
@@ -33,7 +50,7 @@ MooX::Role::Parameterized:With - dsl to apply roles with composition parameters
 
     use Moo;
     use MooX::Role::Parameterized::With Bar => {
-        attr => 'baz', 
+        attr => 'baz',
         method => 'run'
     }, Other::Role => { ... };
 
@@ -44,7 +61,7 @@ MooX::Role::Parameterized:With - dsl to apply roles with composition parameters
 This B<experimental> package try to offer an easy way to add parametrized roles.
 
 Will load and apply L<MooX::Roles::Parameterized> roles, just need use this package
-with a hash of role => parameters. 
+with a hash of role => parameters.
 
 =head1 AUTHOR
 
@@ -53,4 +70,3 @@ Tiago Peczenyj <tiago (dot) peczenyj (at) gmail (dot) com>
 =head1 BUGS
 
 Please report any bugs or feature requests on the bugtracker website
-


### PR DESCRIPTION
This simplistic commit checks if the parameters are empty ({}) and if they are,
when a role package does not have apply(), fallback to applying using
Moo::Role or Role::Tiny.

This commit is basically just a proof of concept to make classes that use
MooX::Role::Parameterized::With work with Role::Tiny and Moo::Role roles.

One caveat is that the required methods must be declared before including the
role, e.g.:

    package Role1;
    use Role::Tiny;
    requires 'meth1';

    package Class1;
    sub meth1 { ... }
    use MooX::Role::Parameterized::With 'Role1' => {};

A solution for that is for MooX::Role::Parameterized::With to declare 'with'. A
syntax that is compatible with Moose to support non-parametric and parametric
including would be nice, e.g.:

    with 'Role1', 'Role2' => {param=>'for',role=>'Role2'}, ...;