### PR TITLE
Quote the bareword role name in MX:R:With if it contains 2 colons

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MooX::Role::Parameterized - roles with composition parameters
 
     use Moo;
     # experimental way of add roles
-    use MooX::Role::Parameterized::With My::Role => {
+    use MooX::Role::Parameterized::With 'My::Role' => {
         attr => 'baz',
         method => 'run'
     };

--- a/lib/MooX/Role/Parameterized.pm
+++ b/lib/MooX/Role/Parameterized.pm
@@ -80,7 +80,7 @@ MooX::Role::Parameterized - roles with composition parameters
 
     use Moo;
     # experimental way of add roles
-    use MooX::Role::Parameterized::With My::Role => {
+    use MooX::Role::Parameterized::With 'My::Role' => {
         attr => 'baz',
         method => 'run'
     };


### PR DESCRIPTION
Otherwise, the code fails with

  Bareword "Foo::Bar" not allowed while "strict subs" in use at 1.pl line 11.
  Execution of 1.pl aborted due to compilation errors.