### PR TITLE
fix: resolve Kwalitee has_readme issue

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 {{$NEXT}}
+  - fix Kwalitee has_readme issue by adding README to distribution
+  - add INSTALLATION section to documentation
 
 0.700   2026-05-17
   - migrate the build from ExtUtils::MakeMaker to Dist::Zilla

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ MooX::Role::Parameterized - roles with composition parameters
         name => 'zapped',     # methods increment_zapped ( +1 )
     };                        # reset_zapped (set to zero)
 
+# INSTALLATION
+
+To install this module, run the following commands:
+
+    perl Makefile.PL
+    make
+    make test
+    make install
+
+Alternatively, to install with cpanm:
+
+    cpanm .
+
 # DESCRIPTION
 
 It is a port of [MooseX::Role::Parameterized](https://metacpan.org/pod/MooseX%3A%3ARole%3A%3AParameterized) to [Moo](https://metacpan.org/pod/Moo).

--- a/dist.ini
+++ b/dist.ini
@@ -42,7 +42,12 @@ bugtracker.web  = https://github.com/peczenyj/MooX-Role-Parameterized/issues
 filename = Changelog
 format   = %-7v %{yyyy-MM-dd}d
 
-[ReadmeAnyFromPod]
+[ReadmeAnyFromPod / ReadmeTextInBuild]
+type     = text
+filename = README
+location = build
+
+[ReadmeAnyFromPod / ReadmeMdInRoot]
 type     = markdown
 filename = README.md
 location = root

--- a/lib/MooX/Role/Parameterized.pm
+++ b/lib/MooX/Role/Parameterized.pm
@@ -246,6 +246,19 @@ MooX::Role::Parameterized - roles with composition parameters
         name => 'zapped',     # methods increment_zapped ( +1 )
     };                        # reset_zapped (set to zero)
 
+=head1 INSTALLATION
+
+To install this module, run the following commands:
+
+    perl Makefile.PL
+    make
+    make test
+    make install
+
+Alternatively, to install with cpanm:
+
+    cpanm .
+
 =head1 DESCRIPTION
 
 It is a port of L<MooseX::Role::Parameterized> to L<Moo>.


### PR DESCRIPTION
- Update dist.ini to include README in the built distribution using ReadmeAnyFromPod (text)
- Add INSTALLATION section to lib/MooX/Role/Parameterized.pm POD
- Update Changelog to reflect the fix